### PR TITLE
Issue #12: tag metrics on startup

### DIFF
--- a/hawkular-dropwizard-reporter-factory/src/main/java/org/hawkular/metrics/dropwizard/HawkularReporterFactory.java
+++ b/hawkular-dropwizard-reporter-factory/src/main/java/org/hawkular/metrics/dropwizard/HawkularReporterFactory.java
@@ -42,7 +42,6 @@ public class HawkularReporterFactory extends BaseReporterFactory implements Hawk
     private Map<String, String> headers;
     private Map<String, String> globalTags;
     private Map<String, Map<String, String>> perMetricTags;
-    private Long tagsCacheDuration;
     private Boolean autoTagging;
 
     public HawkularReporterFactory() {
@@ -69,7 +68,7 @@ public class HawkularReporterFactory extends BaseReporterFactory implements Hawk
         this.tenant = tenant;
     }
 
-    @JsonProperty
+    @Override @JsonProperty
     public String getUsername() {
         return username;
     }
@@ -79,7 +78,7 @@ public class HawkularReporterFactory extends BaseReporterFactory implements Hawk
         this.username = username;
     }
 
-    @JsonProperty
+    @Override @JsonProperty
     public String getPassword() {
         return password;
     }
@@ -143,17 +142,6 @@ public class HawkularReporterFactory extends BaseReporterFactory implements Hawk
     public void setPerMetricTags(
             Map<String, Map<String, String>> perMetricTags) {
         this.perMetricTags = perMetricTags;
-    }
-
-    @Override
-    @JsonProperty
-    public Long getTagsCacheDuration() {
-        return tagsCacheDuration;
-    }
-
-    @JsonProperty
-    public void setTagsCacheDuration(Long tagsCacheDuration) {
-        this.tagsCacheDuration = tagsCacheDuration;
     }
 
     @Override

--- a/hawkular-dropwizard-reporter/src/main/java/org/hawkular/metrics/dropwizard/HawkularReporter.java
+++ b/hawkular-dropwizard-reporter/src/main/java/org/hawkular/metrics/dropwizard/HawkularReporter.java
@@ -93,20 +93,6 @@ public class HawkularReporter extends ScheduledReporter {
         } catch (IOException e) {
             LOG.error("Could not post metrics data", e);
         }
-        accu.getCountersTags().forEach((metricId, tags) -> {
-            try {
-                hawkularClient.putTags("/counters/" + metricId + "/tags", HawkularJson.tagsToString(tags));
-            } catch (IOException e) {
-                LOG.error("Could not post tags data", e);
-            }
-        });
-        accu.getGaugesTags().forEach((metricId, tags) -> {
-            try {
-                hawkularClient.putTags("/gauges/" + metricId + "/tags", HawkularJson.tagsToString(tags));
-            } catch (IOException e) {
-                LOG.error("Could not post tags data", e);
-            }
-        });
     }
 
     private static void processGauges(DataAccumulator builder, Map<String, Gauge> gauges) {
@@ -175,8 +161,6 @@ public class HawkularReporter extends ScheduledReporter {
     private class DataAccumulator {
         private Map<String, Double> gauges = new HashMap<>();
         private Map<String, Long> counters = new HashMap<>();
-        private Map<String, Map<String, String>> gaugesTags = new HashMap<>();
-        private Map<String, Map<String, String>> countersTags = new HashMap<>();
 
         private DataAccumulator() {
         }
@@ -187,14 +171,6 @@ public class HawkularReporter extends ScheduledReporter {
 
         private Map<String, Long> getCounters() {
             return counters;
-        }
-
-        private Map<String, Map<String, String>> getGaugesTags() {
-            return gaugesTags;
-        }
-
-        private Map<String, Map<String, String>> getCountersTags() {
-            return countersTags;
         }
 
         private DataAccumulator addCounter(String name, long l) {

--- a/hawkular-dropwizard-reporter/src/main/java/org/hawkular/metrics/dropwizard/HawkularReporterBuilder.java
+++ b/hawkular-dropwizard-reporter/src/main/java/org/hawkular/metrics/dropwizard/HawkularReporterBuilder.java
@@ -44,7 +44,6 @@ public class HawkularReporterBuilder {
     private Optional<Function<String, HawkularHttpClient>> httpClientProvider = Optional.empty();
     private final Map<String, String> globalTags = new HashMap<>();
     private final Map<String, Map<String, String>> perMetricTags = new HashMap<>();
-    private long tagsCacheDuration = 1000 * 60 * 10; // In milliseconds; default: 10min
     private boolean enableAutoTagging = true;
 
     /**
@@ -78,9 +77,6 @@ public class HawkularReporterBuilder {
         }
         if (config.getPerMetricTags() != null) {
             this.perMetricTags(config.getPerMetricTags());
-        }
-        if (config.getTagsCacheDuration() != null) {
-            this.tagsCacheDuration(config.getTagsCacheDuration());
         }
         if (config.getAutoTagging() != null && !config.getAutoTagging()) {
             this.disableAutoTagging();
@@ -223,39 +219,6 @@ public class HawkularReporterBuilder {
     }
 
     /**
-     * Set the eviction duration of tags cache (in milliseconds)<br/>
-     * This cache is used to prevent the reporter from tagging the metrics when they were already tagged<br/>
-     * Default duration is 10 minutes
-     * @param milliseconds number of milliseconds before eviction
-     */
-    public HawkularReporterBuilder tagsCacheDuration(long milliseconds) {
-        tagsCacheDuration = milliseconds;
-        return this;
-    }
-
-    /**
-     * Set the eviction duration of tags cache, in minutes<br/>
-     * This cache is used to prevent the reporter from tagging the metrics when they were already tagged<br/>
-     * Default duration is 10 minutes
-     * @param minutes number of minutes before eviction
-     */
-    public HawkularReporterBuilder tagsCacheDurationInMinutes(long minutes) {
-        tagsCacheDuration = TimeUnit.MILLISECONDS.convert(minutes, TimeUnit.MINUTES);
-        return this;
-    }
-
-    /**
-     * Set the eviction duration of tags cache, in hours<br/>
-     * This cache is used to prevent the reporter from tagging the metrics when they were already tagged<br/>
-     * Default duration is 10 minutes
-     * @param hours number of hours before eviction
-     */
-    public HawkularReporterBuilder tagsCacheDurationInHours(long hours) {
-        tagsCacheDuration = TimeUnit.MILLISECONDS.convert(hours, TimeUnit.HOURS);
-        return this;
-    }
-
-    /**
      * Use a custom {@link HawkularHttpClient}
      * @param httpClientProvider function that provides a custom {@link HawkularHttpClient} from input URI as String
      */
@@ -272,7 +235,7 @@ public class HawkularReporterBuilder {
                 .map(provider -> provider.apply(uri))
                 .orElseGet(() -> new JdkHawkularHttpClient(uri));
         client.addHeaders(headers);
-        return new HawkularReporter(registry, client, prefix, globalTags, perMetricTags, tagsCacheDuration,
-                enableAutoTagging, rateUnit, durationUnit, filter);
+        return new HawkularReporter(registry, client, prefix, globalTags, perMetricTags, enableAutoTagging, rateUnit,
+                durationUnit, filter);
     }
 }

--- a/hawkular-dropwizard-reporter/src/main/java/org/hawkular/metrics/dropwizard/MetricComposer.java
+++ b/hawkular-dropwizard-reporter/src/main/java/org/hawkular/metrics/dropwizard/MetricComposer.java
@@ -16,19 +16,14 @@
  */
 package org.hawkular.metrics.dropwizard;
 
-import java.util.Map;
-
 /**
  * @author Joel Takvorian
  */
-public interface HawkularReporterNullableConfig {
-    String getUri();
-    String getBearerToken();
-    String getPrefix();
-    Map<String, String> getHeaders();
-    Map<String, String> getGlobalTags();
-    Map<String, Map<String, String>> getPerMetricTags();
-    Boolean getAutoTagging();
-    String getUsername();
-    String getPassword();
+interface MetricComposer<T,U> {
+    U getData(T input);
+    String getSuffix();
+    String getMetricType();
+    default String getMetricNameWithSuffix(String name) {
+        return name + "." + getSuffix();
+    }
 }

--- a/hawkular-dropwizard-reporter/src/main/java/org/hawkular/metrics/dropwizard/MetricComposers.java
+++ b/hawkular-dropwizard-reporter/src/main/java/org/hawkular/metrics/dropwizard/MetricComposers.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.dropwizard;
+
+import static org.hawkular.metrics.dropwizard.MetricsTagger.METRIC_TYPE_COUNTER;
+import static org.hawkular.metrics.dropwizard.MetricsTagger.METRIC_TYPE_GAUGE;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+
+import com.codahale.metrics.Counting;
+import com.codahale.metrics.Metered;
+import com.codahale.metrics.Sampling;
+
+/**
+ * @author Joel Takvorian
+ */
+public final class MetricComposers {
+
+    static final List<MetricComposer<Counting, Long>> COUNTINGS;
+    static final List<MetricComposer<Metered, Object>> METERED;
+    static final List<MetricComposer<Sampling, Object>> SAMPLING;
+
+    static {
+        COUNTINGS = new ArrayList<>(1);
+        COUNTINGS.add(metricComposer(Counting::getCount, "count", METRIC_TYPE_COUNTER));
+        METERED = new ArrayList<>(4);
+        METERED.add(metricComposer(Metered::getOneMinuteRate, "1min", METRIC_TYPE_GAUGE));
+        METERED.add(metricComposer(Metered::getFiveMinuteRate, "5min", METRIC_TYPE_GAUGE));
+        METERED.add(metricComposer(Metered::getFifteenMinuteRate, "15min", METRIC_TYPE_GAUGE));
+        METERED.add(metricComposer(Metered::getMeanRate, "mean", METRIC_TYPE_GAUGE));
+        SAMPLING = new ArrayList<>(10);
+        SAMPLING.add(metricComposer(s -> s.getSnapshot().getMin(), "min", METRIC_TYPE_GAUGE));
+        SAMPLING.add(metricComposer(s -> s.getSnapshot().getMax(), "max", METRIC_TYPE_GAUGE));
+        SAMPLING.add(metricComposer(s -> s.getSnapshot().getMean(), "mean", METRIC_TYPE_GAUGE));
+        SAMPLING.add(metricComposer(s -> s.getSnapshot().getMedian(), "median", METRIC_TYPE_GAUGE));
+        SAMPLING.add(metricComposer(s -> s.getSnapshot().getStdDev(), "stddev", METRIC_TYPE_GAUGE));
+        SAMPLING.add(metricComposer(s -> s.getSnapshot().get75thPercentile(), "75perc", METRIC_TYPE_GAUGE));
+        SAMPLING.add(metricComposer(s -> s.getSnapshot().get95thPercentile(), "95perc", METRIC_TYPE_GAUGE));
+        SAMPLING.add(metricComposer(s -> s.getSnapshot().get98thPercentile(), "98perc", METRIC_TYPE_GAUGE));
+        SAMPLING.add(metricComposer(s -> s.getSnapshot().get99thPercentile(), "99perc", METRIC_TYPE_GAUGE));
+        SAMPLING.add(metricComposer(s -> s.getSnapshot().get999thPercentile(), "999perc", METRIC_TYPE_GAUGE));
+    }
+
+    private MetricComposers() {
+    }
+
+    private static <T,U> MetricComposer<T,U> metricComposer(Function<T,U> getter, String suffix, String type) {
+        return new MetricComposer<T, U>() {
+            @Override public U getData(T input) {
+                return getter.apply(input);
+            }
+
+            @Override public String getSuffix() {
+                return suffix;
+            }
+
+            @Override public String getMetricType() {
+                return type;
+            }
+        };
+    }
+}

--- a/hawkular-dropwizard-reporter/src/main/java/org/hawkular/metrics/dropwizard/MetricsTagger.java
+++ b/hawkular-dropwizard-reporter/src/main/java/org/hawkular/metrics/dropwizard/MetricsTagger.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.dropwizard;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import org.hawkular.metrics.reporter.http.HawkularHttpClient;
+import org.hawkular.metrics.reporter.http.HawkularJson;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.MetricRegistryListener;
+import com.codahale.metrics.Timer;
+
+/**
+ * @author Joel Takvorian
+ */
+class MetricsTagger implements MetricRegistryListener {
+
+    static final String METRIC_TYPE_COUNTER = "counters";
+    static final String METRIC_TYPE_GAUGE = "gauges";
+
+    private final Optional<String> prefix;
+    private final Map<String, String> globalTags;
+    private final Map<String, Map<String, String>> perMetricTags;
+    private final boolean enableAutoTagging;
+    private final HawkularHttpClient hawkularClient;
+
+    MetricsTagger(Optional<String> prefix, Map<String, String> globalTags, Map<String, Map<String, String>>
+            perMetricTags, boolean enableAutoTagging, HawkularHttpClient hawkularClient, MetricRegistry registry) {
+        this.prefix = prefix;
+        this.globalTags = globalTags;
+        this.perMetricTags = perMetricTags;
+        this.enableAutoTagging = enableAutoTagging;
+        this.hawkularClient = hawkularClient;
+
+        // Initialize with existing metrics
+        registry.getGauges().forEach(this::onGaugeAdded);
+        registry.getCounters().forEach(this::onCounterAdded);
+        registry.getHistograms().forEach(this::onHistogramAdded);
+        registry.getTimers().forEach(this::onTimerAdded);
+        registry.getMeters().forEach(this::onMeterAdded);
+
+        registry.addListener(this);
+    }
+
+    private void tagMetric(String baseName, MetricComposer<?,?> metricComposer, String tagKey) {
+        String nameWithSuffix = metricComposer.getMetricNameWithSuffix(baseName);
+        String fullName = prefix.map(p -> p + nameWithSuffix).orElse(nameWithSuffix);
+        Map<String, String> tags = new LinkedHashMap<>(globalTags);
+        if (enableAutoTagging) {
+            tags.put(tagKey, metricComposer.getSuffix());
+        }
+        // Don't use prefixed name for per-metric tagging
+        if (perMetricTags.containsKey(baseName)) {
+            tags.putAll(perMetricTags.get(baseName));
+        }
+        if (perMetricTags.containsKey(nameWithSuffix)) {
+            tags.putAll(perMetricTags.get(nameWithSuffix));
+        }
+        if (!tags.isEmpty()) {
+            try {
+                hawkularClient.putTags("/" + metricComposer.getMetricType()
+                        + "/" + fullName + "/tags", HawkularJson.tagsToString(tags));
+            } catch (IOException e) {
+                throw new RuntimeException("Could not tag metric " + baseName, e);
+            }
+        }
+    }
+
+    private void tagMetric(String metricType, String baseName) {
+        String fullName = prefix.map(p -> p + baseName).orElse(baseName);
+        Map<String, String> tags = new LinkedHashMap<>(globalTags);
+        // Don't use prefixed name for per-metric tagging
+        if (perMetricTags.containsKey(baseName)) {
+            tags.putAll(perMetricTags.get(baseName));
+        }
+        if (!tags.isEmpty()) {
+            try {
+                hawkularClient.putTags("/" + metricType
+                        + "/" + fullName + "/tags", HawkularJson.tagsToString(tags));
+            } catch (IOException e) {
+                throw new RuntimeException("Could not tag metric " + baseName, e);
+            }
+        }
+    }
+
+    @Override public void onGaugeAdded(String name, Gauge<?> gauge) {
+        tagMetric(METRIC_TYPE_GAUGE, name);
+    }
+
+    @Override public void onGaugeRemoved(String name) {
+    }
+
+    @Override public void onCounterAdded(String name, Counter counter) {
+        tagMetric(METRIC_TYPE_COUNTER, name);
+    }
+
+    @Override public void onCounterRemoved(String name) {
+    }
+
+    @Override public void onHistogramAdded(String name, Histogram histogram) {
+        for (MetricComposer<?,?> metricComposer : MetricComposers.COUNTINGS) {
+            tagMetric(name, metricComposer, "histogram");
+        }
+        for (MetricComposer<?,?> metricComposer : MetricComposers.SAMPLING) {
+            tagMetric(name, metricComposer, "histogram");
+        }
+    }
+
+    @Override public void onHistogramRemoved(String name) {
+    }
+
+    @Override public void onMeterAdded(String name, Meter meter) {
+        for (MetricComposer<?,?> metricComposer : MetricComposers.COUNTINGS) {
+            tagMetric(name, metricComposer, "meter");
+        }
+        for (MetricComposer<?,?> metricComposer : MetricComposers.METERED) {
+            tagMetric(name, metricComposer, "meter");
+        }
+    }
+
+    @Override public void onMeterRemoved(String name) {
+    }
+
+    @Override public void onTimerAdded(String name, Timer timer) {
+        for (MetricComposer<?,?> metricComposer : MetricComposers.COUNTINGS) {
+            tagMetric(name, metricComposer, "timer");
+        }
+        for (MetricComposer<?,?> metricComposer : MetricComposers.METERED) {
+            tagMetric(name, metricComposer, "timer");
+        }
+        for (MetricComposer<?,?> metricComposer : MetricComposers.SAMPLING) {
+            tagMetric(name, metricComposer, "timer");
+        }
+    }
+
+    @Override public void onTimerRemoved(String name) {
+    }
+
+    Map<String, String> getGlobalTags() {
+        return globalTags;
+    }
+
+    Map<String, Map<String, String>> getPerMetricTags() {
+        return perMetricTags;
+    }
+
+    boolean isEnableAutoTagging() {
+        return enableAutoTagging;
+    }
+}


### PR DESCRIPTION
It uses a listener on the registry to know whenever a metric is created.

@jsanda I haven't tested it for real, but there's a small set of unit & integration tests that are OK. Do you plan to test with the cassandra reporter?