### PR TITLE
Implement regex matching for metrics tag

### DIFF
--- a/hawkular-dropwizard-reporter/src/main/java/org/hawkular/metrics/dropwizard/HawkularReporter.java
+++ b/hawkular-dropwizard-reporter/src/main/java/org/hawkular/metrics/dropwizard/HawkularReporter.java
@@ -17,6 +17,7 @@
 package org.hawkular.metrics.dropwizard;
 
 import java.math.BigDecimal;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -51,6 +52,7 @@ public class HawkularReporter extends ScheduledReporter {
                      Optional<String> prefix,
                      Map<String, String> globalTags,
                      Map<String, Map<String, String>> perMetricTags,
+                     Collection<RegexTags> regexTags,
                      boolean enableAutoTagging,
                      TimeUnit rateUnit,
                      TimeUnit durationUnit,
@@ -60,8 +62,8 @@ public class HawkularReporter extends ScheduledReporter {
         this.prefix = prefix;
         this.clock = Clock.defaultClock();
         this.hawkularClient = hawkularClient;
-        metricsTagger = new MetricsTagger(prefix, globalTags, perMetricTags, enableAutoTagging, hawkularClient,
-                registry, filter);
+        metricsTagger = new MetricsTagger(prefix, globalTags, perMetricTags, regexTags, enableAutoTagging,
+                hawkularClient, registry, filter);
     }
 
     @Override
@@ -139,8 +141,8 @@ public class HawkularReporter extends ScheduledReporter {
         return hawkularClient;
     }
 
-    public Map<String, Map<String, String>> getPerMetricTags() {
-        return metricsTagger.getPerMetricTags();
+    public Map<String, String> getTagsForMetrics(String m) {
+        return metricsTagger.getTagsForMetrics(m);
     }
 
     public boolean isEnableAutoTagging() {

--- a/hawkular-dropwizard-reporter/src/main/java/org/hawkular/metrics/dropwizard/MetricComposers.java
+++ b/hawkular-dropwizard-reporter/src/main/java/org/hawkular/metrics/dropwizard/MetricComposers.java
@@ -30,7 +30,7 @@ import com.codahale.metrics.Sampling;
 /**
  * @author Joel Takvorian
  */
-public final class MetricComposers {
+final class MetricComposers {
 
     static final List<MetricComposer<Counting, Long>> COUNTINGS;
     static final List<MetricComposer<Metered, Object>> METERED;

--- a/hawkular-dropwizard-reporter/src/main/java/org/hawkular/metrics/dropwizard/RegexTags.java
+++ b/hawkular-dropwizard-reporter/src/main/java/org/hawkular/metrics/dropwizard/RegexTags.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.dropwizard;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+/**
+ * @author Joel Takvorian
+ */
+class RegexTags {
+    private final Pattern regex;
+    private final Map<String, String> tags;
+
+    RegexTags(Pattern regex, Map<String, String> tags) {
+        this.regex = regex;
+        this.tags = tags;
+    }
+
+    static Optional<RegexTags> checkAndCreate(String maybeRegex, Map<String, String> tags) {
+        if (maybeRegex.startsWith("/") && maybeRegex.endsWith("/")) {
+            try {
+                Pattern regex = Pattern.compile(maybeRegex.substring(1, maybeRegex.length() - 1));
+                return Optional.of(new RegexTags(regex, tags));
+            } catch (PatternSyntaxException e) {
+                return Optional.empty();
+            }
+        }
+        return Optional.empty();
+    }
+
+    Optional<Map<String, String>> match(String metricName) {
+        if (regex.matcher(metricName).find()) {
+            return Optional.of(tags);
+        }
+        return Optional.empty();
+    }
+}

--- a/hawkular-dropwizard-reporter/src/test/java/org/hawkular/metrics/dropwizard/RegexTagsTest.java
+++ b/hawkular-dropwizard-reporter/src/test/java/org/hawkular/metrics/dropwizard/RegexTagsTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2016 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.hawkular.metrics.dropwizard;
+
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import org.junit.Test;
+
+/**
+ * @author Joel Takvorian
+ */
+public class RegexTagsTest {
+
+    @Test
+    public void shouldCheckAndCreate() throws Exception {
+        Optional<RegexTags> result = RegexTags.checkAndCreate("/^some[\\s]regex$/", Collections.singletonMap("k", "v"));
+        assertThat(result)
+                .flatMap(r -> r.match("some\tregex"))
+                .isPresent()
+                .hasValueSatisfying(tags ->
+                        assertThat(tags).containsExactly(entry("k", "v")));
+
+        assertThat(result)
+                .flatMap(r -> r.match("some\tregex\tnot\tmatching"))
+                .isNotPresent();
+    }
+
+    @Test
+    public void shouldCheckAndNotCreate() throws Exception {
+        Optional<RegexTags> result = RegexTags.checkAndCreate("/{}won't compile/", Collections.singletonMap("k", "v"));
+        assertThat(result).isEmpty();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.5.2</version>
+        <version>3.6.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Implements #7 

Regex can be inserted in yaml under "perMetricTags". They are recognized as regex when the string starts and ends with "/".